### PR TITLE
Fixed one of @Strikingwolf's mistakes. As normal :P

### DIFF
--- a/src/main/java/pt/uptodate/UpToDate.java
+++ b/src/main/java/pt/uptodate/UpToDate.java
@@ -144,7 +144,7 @@ public class UpToDate implements IUpdateable
 	 * Registers an updateable to uptodate's registries
 	 * @param updateable the IUpdateable to register
 	 */
-	public void registerUpdateable(IUpdateable updateable) {
+	public static void registerUpdateable(IUpdateable updateable) {
 		FetchedUpdateable toBe = new FetchedUpdateable(updateable);
 		if (toBe.diff > 0) {
 			updates.add(toBe);


### PR DESCRIPTION
Now people don't need to create a new instance of UpToDate to register extra IUpdateables.

How practical :smile: 
